### PR TITLE
1.5 fix for salvage

### DIFF
--- a/src/net/dmulloy2/swornrpg/listeners/PlayerListener.java
+++ b/src/net/dmulloy2/swornrpg/listeners/PlayerListener.java
@@ -146,6 +146,7 @@ public class PlayerListener implements Listener
 							ItemStack itm = new ItemStack(give.getId(), amt + (int)amtIron);
 							inv.setItem(slot, itm);
 							pl.updateInventory();
+							event.setCancelled(true);
 					}
 					catch (Exception e)
 					{


### PR DESCRIPTION
If the salvage is successful, the item needs to be removed from the inventory, not equipped, so the equip function is cancelled.
