### PR TITLE
1.5 equip bug from right-click in salvage

### DIFF
--- a/src/net/dmulloy2/swornrpg/listeners/PlayerListener.java
+++ b/src/net/dmulloy2/swornrpg/listeners/PlayerListener.java
@@ -146,6 +146,7 @@ public class PlayerListener implements Listener
 							ItemStack itm = new ItemStack(give.getId(), amt + (int)amtIron);
 							inv.setItem(slot, itm);
 							pl.updateInventory();
+							event.setCancelled(true);
 					}
 					catch (Exception e)
 					{
@@ -219,6 +220,7 @@ public class PlayerListener implements Listener
 							ItemStack itm = new ItemStack(give.getId(), amt + (int)amtIron);
 							inv.setItem(slot, itm);
 							pl.updateInventory();
+							event.setCancelled(true);
 					}
 					catch (Exception localException1)
 					{
@@ -290,6 +292,7 @@ public class PlayerListener implements Listener
 							ItemStack itm = new ItemStack(give.getId(), amt + (int)amtIron);
 							inv.setItem(slot, itm);
 							pl.updateInventory();
+							event.setCancelled(true);
 					}
 					catch (Exception localException2)
 					{


### PR DESCRIPTION
Fixed by cancelling equip event (I think). I plan to do a bigger update that pulls salvages from config file - I will make the salvage method generic if you or seven loads a string from the config - you have a special way of doing this in another class file or something :p
