### PR TITLE
None of these if statementes are necessary anymore

### DIFF
--- a/src/net/dmulloy2/swornrpg/listeners/PlayerListener.java
+++ b/src/net/dmulloy2/swornrpg/listeners/PlayerListener.java
@@ -86,37 +86,13 @@ public class PlayerListener implements Listener
 				double mult = 1.0D - ((double) item.getDurability() / item.getType().getMaxDurability());
 				double amtIron = 0;
 				if (mitem.equals(Material.IRON_BOOTS))
-				{
 					amtIron = Math.floor(this.bootsMax * mult);
-					if (amtIron < 0.0D) 
-					{
-						amtIron = 1.0D;
-					}
-				}
 				if (mitem.equals(Material.IRON_HELMET)) 
-				{
 					amtIron = Math.floor(this.HelmMax * mult);
-					if (amtIron < 0.0D) 
-					{
-						amtIron = 1.0D;
-					}
-				}
 				if (mitem.equals(Material.IRON_LEGGINGS)) 
-				{
 					amtIron = Math.floor(this.LegsMax * mult);
-					if (amtIron < 0.0D)
-					{
-						amtIron = 1.0D;
-					}
-				}
 				if (mitem.equals(Material.IRON_CHESTPLATE))
-				{
 					amtIron = Math.floor(this.ChestMax * mult);
-					if (amtIron < 0.0D) 
-					{
-						amtIron = 1.0D;
-					}
-				}
 				if (amtIron > 0.0D)
 				{
 					pl.sendMessage(ChatColor.GRAY + "You have salvaged an " + mitem.toString().toLowerCase().replaceAll("_", " ") + " for " + amtIron + " iron ingot(s)");
@@ -142,37 +118,13 @@ public class PlayerListener implements Listener
 				double mult = 1.0D - ((double) item.getDurability() / item.getType().getMaxDurability());
 				double amtIron = 0.0D;
 				if (mitem.equals(Material.DIAMOND_BOOTS))   
-				{
 					amtIron = Math.floor(this.bootsMax * mult);
-				}
-				if (amtIron < 0.0D)
-				{
-					amtIron = 1.0D;
-				}
 				if (mitem.equals(Material.DIAMOND_HELMET)) 
-				{
 					amtIron = Math.floor(this.HelmMax * mult);
-					if (amtIron < 0.0D)
-					{
-						amtIron = 1.0D;
-					}
-				}
 				if (mitem.equals(Material.DIAMOND_LEGGINGS))
-				{
 					amtIron = Math.floor(this.LegsMax * mult);
-					if (amtIron < 0.0D) 
-					{
-						amtIron = 1.0D;
-					}
-				}
 				if (mitem.equals(Material.DIAMOND_CHESTPLATE)) 
-				{
 					amtIron = Math.floor(this.ChestMax * mult);
-					if (amtIron < 0.0D) 
-					{
-						amtIron = 1.0D;
-					}
-					}
 				amtIron -= 1.0D;
 				if (amtIron > 0.0D)
 				{
@@ -199,37 +151,13 @@ public class PlayerListener implements Listener
 				double mult = 1.0D - ((double) item.getDurability() / item.getType().getMaxDurability());
 				double amtIron = 0.0D;
 				if (mitem.equals(Material.GOLD_BOOTS))   
-				{
 					amtIron = Math.floor(this.bootsMax * mult);
-				}
-				if (amtIron < 0.0D)
-				{
-					amtIron = 1.0D;
-				}
 				if (mitem.equals(Material.GOLD_HELMET)) 
-				{
 					amtIron = Math.floor(this.HelmMax * mult);
-					if (amtIron < 0.0D)
-					{
-						amtIron = 1.0D;
-					}
-				}
 				if (mitem.equals(Material.GOLD_LEGGINGS))
-				{
 					amtIron = Math.floor(this.LegsMax * mult);
-					if (amtIron < 0.0D) 
-					{
-						amtIron = 1.0D;
-					}
-				}
 				if (mitem.equals(Material.GOLD_CHESTPLATE)) 
-				{
 					amtIron = Math.floor(this.ChestMax * mult);
-					if (amtIron < 0.0D) 
-					{
-						amtIron = 1.0D;
-					}
-				}
 				amtIron -= 1.0D;
 				if (amtIron > 0.0D)
 				{


### PR DESCRIPTION
Because of the way orange did %durability... it was weird, but these are no longer necessary. Also, why do you put amtIron -= 1.0D at the end of only diamond and gold? If you want to give the user 1 less ingot for any salvage, that will send them the wrong error message if they do not have enough durability left to get a single ingot (as the if statements I deleted were <1, not <=1).
